### PR TITLE
Adds gunicorn for production environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ python run.py
 
 Use the status check endpoint located at `localhost:5000/status` in order to check the status of the database connection.
 
-## Production Running
+## Production Deployment 
 
 Use `gunicorn` to run the application behind a production-grade WSGI server.
 The Flask development server is not suitable for production use.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ python run.py
 
 Use the status check endpoint located at `localhost:5000/status` in order to check the status of the database connection.
 
+## Production Running
+
+Use `gunicorn` to run the application behind a production-grade WSGI server.
+The Flask development server is not suitable for production use.
+
+```
+gunicorn -w 4 -b 127.0.0.1:5000 application_name.app:app
+```
+This command produces 4 workers and binds to port 5000.
+
+Use the status checkpoint, `localhost:5000/status` to verify the service is healthy.
+
 # Adding Resources: Models, Views, Routes, and Blueprints
 
 All models should extend `application_name.database.BaseModel`. Models, views, and Blueprints should all be added to the respective resource module in the `application_name/` directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest==5.2.2
 pytest-cov==2.8.1
 python-dotenv==0.10.3
 Flask-Migrate==2.5.2
+gunicorn==19.9.0


### PR DESCRIPTION
Hello @lindseybrockman @thejessleigh,
For production, we'll want to leverage something a little more beefy than the Flask webserver. Following the Flask documentation, https://flask.palletsprojects.com/en/1.1.x/deploying/#deployment I've chosen `gunicorn` for the WSGI server. It's worked for me in the past and is pretty easy to implement. 

I've intended the command to change for whatever `application_name` is determined to be. Any suggestions on how to document this? 
